### PR TITLE
Webform Continue 404 Error Upon Return from Processor

### DIFF
--- a/webform_paymethod_select.module
+++ b/webform_paymethod_select.module
@@ -22,18 +22,25 @@ require_once dirname(__FILE__) . '/webform_paymethod_select.webform.inc';
  * Implements hook_menu().
  */
 function webform_paymethod_select_menu() {
-  $menu['node/%node/webform-continue/%webform_menu_submission/%'] = array(
-    'title callback' => 'node_page_title',
+  $menu['node/%webform_paymethod_select_submission/webform-continue/%/%'] = array(
+    'title callback' => 'webform_paymethod_select_page_title',
     'title arguments' => array(1),
     'page callback' => 'webform_paymethod_select_continue',
-    'page arguments' => array(1, 3, 4),
+    'page arguments' => array(1, 4),
     'access callback' => 'webform_paymethod_select_continue_access',
-    'access arguments' => array(1, 3, 4),
-    'load arguments' => array(1),
+    'access arguments' => array(1, 4),
+    'load arguments' => array(3),
     'type' => MENU_CALLBACK,
     'file' => 'webform_paymethod_select.pages.inc',
   );
   return $menu;
+}
+
+/**
+ * Load callback: Load a webform submission.
+ */
+function webform_paymethod_select_submission_load($nid, $sid) {
+  return Submission::load($nid, $sid);
 }
 
 function _webform_paymethod_select_reenter_hash($nid, $sid, $page_num) {
@@ -41,7 +48,8 @@ function _webform_paymethod_select_reenter_hash($nid, $sid, $page_num) {
   return drupal_hmac_base64("$nid:$sid:$page_num", $key);
 }
 
-function webform_paymethod_select_continue_access($node, $submission, $page_num) {
+function webform_paymethod_select_continue_access($submission, $page_num) {
+  $node = $submission->node;
   if (empty($node->webform) || empty($node->webform['components'])) {
     return FALSE;
   }

--- a/webform_paymethod_select.pages.inc
+++ b/webform_paymethod_select.pages.inc
@@ -1,13 +1,21 @@
 <?php
 
 /**
+ * Title callback: Get node title from submission object.
+ */
+function webform_paymethod_select_page_title($submission) {
+  return $submission->node->title;
+}
+
+/**
  * Page callback for continuing a webform submission after payment.
  */
-function webform_paymethod_select_continue($node, $submission, $page_num) {
+function webform_paymethod_select_continue($submission, $page_num) {
   // We can't use a simple drupal_get_form() because we wan't to enter the form
   // at a specific $page_num.
   $form_state = array();
 
+  $node = $submission->node;
   $args = array($node, $submission, TRUE, TRUE);
   $form_state['build_info']['args'] = $args;
 


### PR DESCRIPTION
A custom title and load handler is needed as it’s impossible to satisfy
both of:
  - node_load($nid, $vid = NULL, …)
  - webform_menu_get_submission($nid, $sid)

The former way of specifying 'load_arguments' was bogus too since the
function automatically gets the argument on it’s own position.