### PR TITLE
Only call webform_client_form_submit once

### DIFF
--- a/webform_paymethod_select.module
+++ b/webform_paymethod_select.module
@@ -248,6 +248,9 @@ function webform_paymethod_select_form_submit($form, &$form_state) {
       // Completely repopulate the $form_state['storage'] if needed.
       $form_state += ['storage' => []];
       $form_state['storage'] += $form_state['webform'];
+      if (!isset($form_state['storage']['submitted'])) {
+        $form_state['storage']['submitted'] = $form_state['values']['submitted'];
+      }
 
       // Redirect instead of rebuild if all non-success-components are pending.
       if ($pending) {


### PR DESCRIPTION
`webform_paymethod_select_form_submit` calls `webform_client_form_submit` before validating a payment, which works as expected on the first submission attempt of the webform and the webform module creates a new submission (see `webform.module` in the webform module, lines 3386-3392). If the payment failed and the form is submitted again, the webform module clears all form data that has previously been submitted (see `webform.module` lines 3365-3386). The previously submitted data contains relevant information like the payment amount, which is then no longer available if the submission is accessed via `webform_get_submission`.