### PR TITLE
Fix re-entering a webform (again).

### DIFF
--- a/webform_paymethod_select.info
+++ b/webform_paymethod_select.info
@@ -9,7 +9,7 @@ dependencies[] = payment (>1.5)
 dependencies[] = payment_context
 dependencies[] = payment_forms
 dependencies[] = psr0
-dependencies[] = webform
+dependencies[] = webform (>=4.11)
 
 stylesheets[all][] = webform_paymethod_select.css
 

--- a/webform_paymethod_select.pages.inc
+++ b/webform_paymethod_select.pages.inc
@@ -16,18 +16,10 @@ function webform_paymethod_select_continue($submission, $page_num) {
   $form_state = array();
 
   $node = $submission->node;
-  $args = array($node, $submission->unwrap(), TRUE, TRUE);
-  $form_state['build_info']['args'] = $args;
-
-  $form_state['storage']['component_tree'] = array();
-  $form_state['storage']['page_count'] = 1;
-  $form_state['storage']['preview'] = !empty($node->webform['preview']);
-  _webform_components_tree_build($node->webform['components'], $form_state['storage']['component_tree'], 0, $form_state['storage']['page_count']);
-  $form_state['storage']['page_num'] = $page_num;
-  $form_state['storage']['page_visited'] = $page_num;
-  if (module_exists('webform_steps')) {
-    $form_state['steps_finished'] = $page_num - 1;
-  }
-
+  $submission = $submission->unwrap();
+  $submission->highest_valid_page = $page_num - 1;
+  $form_state['build_info']['args'] = [$node, $submission, FALSE, TRUE];
+  // Needed to accomodate little_helpers.
+  $form_state['values']['details']['sid'] = $submission->sid;
   return drupal_build_form('webform_client_form_' . $node->nid, $form_state);
 }


### PR DESCRIPTION
Trigger the code in `webform_client_form()` that is used to restart a
draft submission, because that’s exactly what we want to do.

It’s all about passing the right arguments to `webform_client_form()`.
Since these changes once in a while we need to narrow down the supported
webform versions.