### PR TITLE
Save the submission when the payment is saved in AJAX callbacks

### DIFF
--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\webform_paymethod_select;
+
+use Drupal\little_helpers\Webform\Submission;
+use Upal\DrupalUnitTestCase;
+
+/**
+ * Test the webform component object.
+ */
+class ComponentTest extends DrupalUnitTestCase {
+
+  /**
+   * Create a test node.
+   */
+  public function setUp() {
+    parent::setUp();
+    module_load_include('inc', 'webform', 'includes/webform.components');
+    module_load_include('inc', 'webform', 'includes/webform.submissions');
+    $node = (object) [
+      'type' => 'webform',
+      'title' => static::class,
+    ];
+    node_object_prepare($node);
+    $node->webform['components'][1] = [
+      'type' => 'paymethod_select',
+    ];
+    $node->webform['components'][2] = [
+      'type' => 'email',
+    ];
+    foreach ($node->webform['components'] as $cid => &$component) {
+      $component['cid'] = $cid;
+      webform_component_defaults($component);
+    }
+    node_save($node);
+    $this->node = node_load($node->nid);
+    $this->payment = NULL;
+  }
+
+  /**
+   * Delete the test node.
+   */
+  public function tearDown() {
+    node_delete($this->node->nid);
+    if ($this->payment) {
+      entity_delete('payment', $this->payment->pid);
+    }
+    parent::tearDown();
+  }
+
+  /**
+   * Test invoking the AJAX callback.
+   */
+  public function testAjaxCallback() {
+    $component = new Component($this->node->webform['components'][1]);
+    $controller = $this->getMockBuilder(\PaymentMethodController::class)
+      ->setMethods(['ajaxCallback'])
+      ->getMock();
+    $self = $this;
+    $controller->method('ajaxCallback')->will($this->returnCallback(function (\Payment $payment) use ($self) {
+      // Component::render() unsets this, but payment_context_entity_presave()
+      // expects it to be at least NULL.
+      $payment->contextObj = NULL;
+      entity_save('payment', $payment);
+      $self->payment = $payment;
+    }));
+    $method = entity_create('payment_method', [
+      'controller' => $controller,
+    ]);
+    $element = webform_component_invoke('paymethod_select', 'render', $this->node->webform['components'][1]);
+    $form = ['#node' => $this->node];
+    $form_state = [];
+    $component->render($element, $form, $form_state);
+    $component->executeAjaxCallback($method, $form, $form_state);
+
+    // The $submission->sid is in the right place to be found in the following
+    // form submit.
+    $this->assertNotEmpty($form['details']['sid']['#value']);
+
+    // Load and inspect the submission and payment.
+    $submission = Submission::load($this->node->nid, $form['details']['sid']['#value']);
+    $payment = entity_load_single('payment', $submission->data[1][0]);
+    $this->assertEqual([
+      'nid' => $this->node->nid,
+      'sid' => $form['details']['sid']['#value'],
+      'cid' => 1,
+    ], $payment->contextObj->toContextData());
+  }
+
+}

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\webform_paymethod_select;
+
+use Drupal\little_helpers\Webform\Submission;
+use Upal\DrupalUnitTestCase;
+
+/**
+ * Test for form handling functions.
+ */
+class FormTest extends DrupalUnitTestCase {
+
+  /**
+   * Create a test node.
+   */
+  public function setUp() {
+    parent::setUp();
+    module_load_include('inc', 'webform', 'includes/webform.components');
+    $node = (object) [
+      'type' => 'webform',
+      'title' => static::class,
+    ];
+    node_object_prepare($node);
+    $node->webform['components'][1] = [
+      'type' => 'paymethod_select',
+    ];
+    $node->webform['components'][2] = [
+      'type' => 'email',
+    ];
+    foreach ($node->webform['components'] as $cid => &$component) {
+      $component['cid'] = $cid;
+      webform_component_defaults($component);
+    }
+    node_save($node);
+    $this->node = $node;
+
+    $GLOBALS['conf']['webform_tracking_mode'] = 'none';
+  }
+
+  /**
+   * Delete the test node.
+   */
+  public function tearDown() {
+    node_delete($this->node->nid);
+    parent::tearDown();
+  }
+
+  /**
+   * Test submitting a form step with one successful payment.
+   */
+  public function testSubmitSuccess() {
+
+    $form_state['clicked_button']['#parents'] = ['next'];
+    $form_state['values']['op'] = 'next';
+    $form_state['webform_completed'] = TRUE;
+    $form_state['webform_paymethod_select']['pages'][1] = [1];
+    $form_state['webform_paymethod_select'][1] = $component = $this->createMock(Component::class);
+    $component->method('value')->willReturn([]);
+    $component->expects($this->once())->method('submit');
+    $form_state['webform']['page_num'] = 1;
+    $form['#node'] = $this->node;
+    $form_state['values']['submitted'][1] = ['payment' => 'data'];
+    $form_state['values']['submitted'][2] = ['test@example.com'];
+    $form_state['values']['details']['sid'] = NULL;
+    webform_paymethod_select_form_submit($form, $form_state);
+
+    // Values have been overridden by the component.
+    $this->assertEqual([], $form_state['values']['submitted'][1]);
+
+    // A webform submission was created.
+    $this->assertNotEmpty($form_state['values']['details']['sid']);
+
+    $submission = Submission::load($this->node->nid, $form_state['values']['details']['sid']);
+    $this->assertEqual([''], $submission->data[1]);
+  }
+
+}

--- a/webform_paymethod_select.module
+++ b/webform_paymethod_select.module
@@ -233,6 +233,7 @@ function webform_paymethod_select_form_webform_client_form_alter(&$form, &$form_
     $parents = $componentObj->parents($webform);
     $element = &drupal_array_get_nested_value($form['submitted'], $parents);
     $componentObj->render($element, $form, $form_state);
+    $form_state['cache'] = TRUE;
   }
 }
 
@@ -250,7 +251,11 @@ function webform_paymethod_select_form_submit($form, &$form_state) {
     return;
   }
   $page_num = $form_state['webform']['page_num'];
-  if (!empty($form_state['webform_paymethod_select']['pages'][$page_num])) {
+  $components = [];
+  foreach ($form_state['webform_paymethod_select']['pages'][$page_num] ?? [] as $cid) {
+    $components[$cid] = $form_state['webform_paymethod_select'][$cid];
+  }
+  if ($components) {
     $draft = !empty($form_state['save_draft']);
     $form_state['save_draft'] = TRUE;
     webform_client_form_submit($form, $form_state);
@@ -258,8 +263,7 @@ function webform_paymethod_select_form_submit($form, &$form_state) {
 
     $success = TRUE;
     $pending = TRUE;
-    foreach ($form_state['webform_paymethod_select']['pages'][$page_num] as $cid) {
-      $component = $form_state['webform_paymethod_select'][$cid];
+    foreach ($components as $component) {
       $component->submit($form, $form_state, $submission);
       $pending = $pending && $component->statusIsOneOf(PAYMENT_STATUS_PENDING, PAYMENT_STATUS_SUCCESS);
       $success = $success && $component->statusIsOneOf(PAYMENT_STATUS_SUCCESS);

--- a/webform_paymethod_select.module
+++ b/webform_paymethod_select.module
@@ -260,7 +260,7 @@ function webform_paymethod_select_form_submit($form, &$form_state) {
     $form_state['save_draft'] = TRUE;
     foreach ($components as $cid => $component) {
       // Avoid saving the submitted payment data.
-      $form_state['values'][$cid] = $component->value();
+      $form_state['values']['submitted'][$cid] = $component->value();
     }
     webform_client_form_submit($form, $form_state);
     $submission = Submission::load($form['#node']->nid, $form_state['values']['details']['sid']);

--- a/webform_paymethod_select.module
+++ b/webform_paymethod_select.module
@@ -65,9 +65,9 @@ function webform_paymethod_select_method_callback($cid, \PaymentMethod $method) 
   form_set_cache($form['#build_id'], $form, $form_state);
 
   // Tell the caller about a possibly changed build id. @see form_get_cache().
-  if (isset($form['#old_build_id'])) {
+  if (isset($form['#build_id_old'])) {
     $result['form_build_id'] = [
-      'old' => $form['#old_build_id'],
+      'old' => $form['#build_id_old'],
       'new' => $form['#build_id'],
     ];
   }

--- a/webform_paymethod_select.module
+++ b/webform_paymethod_select.module
@@ -258,6 +258,10 @@ function webform_paymethod_select_form_submit($form, &$form_state) {
   if ($components) {
     $draft = !empty($form_state['save_draft']);
     $form_state['save_draft'] = TRUE;
+    foreach ($components as $cid => $component) {
+      // Avoid saving the submitted payment data.
+      $form_state['values'][$cid] = $component->value();
+    }
     webform_client_form_submit($form, $form_state);
     $submission = Submission::load($form['#node']->nid, $form_state['values']['details']['sid']);
 


### PR DESCRIPTION
The reason is that we want to avoid having payments without a webform submission as context.